### PR TITLE
fix: 항공사 가입 신청 관리에서 항공사 관리자가 쓰게 될 항공사 관리자 계정 id 자동생성 로직 수정

### DIFF
--- a/backend/src/main/java/com/kh/ct/domain/emp/repository/AirlineRepository.java
+++ b/backend/src/main/java/com/kh/ct/domain/emp/repository/AirlineRepository.java
@@ -24,6 +24,10 @@ public interface AirlineRepository extends JpaRepository<Airline, Long> {
 
     // AirlineApply ID로 Airline 조회
     @Query("SELECT a FROM Airline a WHERE a.airlineApplyId.airlineApplyId = :airlineApplyId")
-    Airline findByAirlineApplyId(@Param("airlineApplyId") Long airlineApplyId);
+    java.util.Optional<Airline> findByAirlineApplyId(@Param("airlineApplyId") Long airlineApplyId);
+    
+    // AirlineApply ID로 Airline 존재 여부 확인
+    @Query("SELECT COUNT(a) > 0 FROM Airline a WHERE a.airlineApplyId.airlineApplyId = :airlineApplyId")
+    boolean existsByAirlineApplyId(@Param("airlineApplyId") Long airlineApplyId);
 }
 

--- a/backend/src/main/java/com/kh/ct/domain/emp/service/AirlineApplyServiceImpl.java
+++ b/backend/src/main/java/com/kh/ct/domain/emp/service/AirlineApplyServiceImpl.java
@@ -51,9 +51,38 @@ public class AirlineApplyServiceImpl implements AirlineApplyService {
     }
 
     @Override
+    @Transactional // readOnly = false로 오버라이드 (Airline 생성 가능하도록)
     public AirlineApplyDto.DetailResponse getApplicationDetail(Long id) {
         AirlineApply application = airlineApplyRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 신청을 찾을 수 없습니다. ID: " + id));
+        
+        // 승인되었지만 Airline이 없는 경우 자동 생성 (기존 승인 건 처리)
+        if (application.getAirlineApplyStatus() == com.kh.ct.global.common.CommonEnums.ApplyStatus.APPROVED) {
+            java.util.Optional<Airline> existingAirlineOpt = airlineRepository.findByAirlineApplyId(application.getAirlineApplyId());
+            if (existingAirlineOpt.isEmpty()) {
+                // Airline 자동 생성
+                Airline newAirline = Airline.builder()
+                        .airlineName(application.getAirlineName())
+                        .theme("gray") // 기본 테마
+                        .mainNumber("") // 기본값
+                        .airlineAddress("") // 기본값
+                        .airlineDesc("") // 기본값
+                        .email(application.getAirlineApplyEmail())
+                        .phone(application.getManagerPhone())
+                        .plan("Professional")
+                        .status(AirlineStatus.ACTIVE)
+                        .icon("✈️")
+                        .country("대한민국")
+                        .joinDate(application.getCreateDate() != null ? 
+                                application.getCreateDate().toLocalDate() : LocalDate.now())
+                        .storageUsage(0.0)
+                        .lastLoginDate(LocalDateTime.now())
+                        .airlineApplyId(application)
+                        .build();
+                airlineRepository.save(newAirline);
+            }
+        }
+        
         return convertToDetailResponse(application);
     }
 
@@ -64,32 +93,52 @@ public class AirlineApplyServiceImpl implements AirlineApplyService {
         AirlineApply application = airlineApplyRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 신청을 찾을 수 없습니다. ID: " + id));
         
-        // 2. 아이디 중복 체크
+        // 2. 이미 승인된 경우 체크
+        if (application.getAirlineApplyStatus() == com.kh.ct.global.common.CommonEnums.ApplyStatus.APPROVED) {
+            throw new IllegalArgumentException("이미 승인된 신청입니다.");
+        }
+        
+        // 3. 아이디 중복 체크
         if (empRepository.findById(adminId).isPresent()) {
             throw new IllegalArgumentException("이미 사용 중인 아이디입니다: " + adminId);
         }
         
-        // 3. 승인 처리
+        // 4. 승인 처리
         application.approve();
         
-        // 4. Airline(테넌트) 엔티티 생성
-        Airline airline = Airline.builder()
-                .airlineName(application.getAirlineName())
-                .email(application.getAirlineApplyEmail())
-                .phone(application.getManagerPhone())
-                .plan("Professional") // 기본 플랜
-                .status(AirlineStatus.ACTIVE)
-                .icon("✈️")
-                .country("대한민국")
-                .joinDate(LocalDate.now())
-                .storageUsage(0.0)
-                .lastLoginDate(LocalDateTime.now())
-                .airlineApplyId(application)
-                .build();
+        // 5. Airline(테넌트) 엔티티 생성 (이미 존재하는지 확인)
+        Airline airline = airlineRepository.findByAirlineApplyId(application.getAirlineApplyId())
+                .orElse(null);
         
-        airlineRepository.save(airline);
+        if (airline == null) {
+            // Airline이 없으면 생성 (중복 체크를 한 번 더 수행)
+            if (!airlineRepository.existsByAirlineApplyId(application.getAirlineApplyId())) {
+                airline = Airline.builder()
+                        .airlineName(application.getAirlineName())
+                        .theme("gray") // 기본 테마
+                        .mainNumber("") // 기본값
+                        .airlineAddress("") // 기본값
+                        .airlineDesc("") // 기본값
+                        .email(application.getAirlineApplyEmail())
+                        .phone(application.getManagerPhone())
+                        .plan("Professional") // 기본 플랜
+                        .status(AirlineStatus.ACTIVE)
+                        .icon("✈️")
+                        .country("대한민국")
+                        .joinDate(LocalDate.now())
+                        .storageUsage(0.0)
+                        .lastLoginDate(LocalDateTime.now())
+                        .airlineApplyId(application)
+                        .build();
+                airline = airlineRepository.save(airline);
+            } else {
+                // 저장 전에 다른 트랜잭션에서 생성되었을 수 있으므로 다시 조회
+                airline = airlineRepository.findByAirlineApplyId(application.getAirlineApplyId())
+                        .orElseThrow(() -> new IllegalStateException("Airline 생성 중 오류가 발생했습니다."));
+            }
+        }
         
-        // 5. 항공사 관리자 계정 생성
+        // 6. 항공사 관리자 계정 생성
         String tempPassword = generateTempPassword();
         String encodedPassword = passwordEncoder.encode(tempPassword);
         
@@ -177,9 +226,9 @@ public class AirlineApplyServiceImpl implements AirlineApplyService {
         // 승인된 경우 Airline ID 조회
         Long airlineId = null;
         if (entity.getAirlineApplyStatus() == com.kh.ct.global.common.CommonEnums.ApplyStatus.APPROVED) {
-            Airline airline = airlineRepository.findByAirlineApplyId(entity.getAirlineApplyId());
-            if (airline != null) {
-                airlineId = airline.getAirlineId();
+            java.util.Optional<Airline> airlineOpt = airlineRepository.findByAirlineApplyId(entity.getAirlineApplyId());
+            if (airlineOpt.isPresent()) {
+                airlineId = airlineOpt.get().getAirlineId();
             }
         }
 

--- a/frontend/src/pages/SuperAdmin/CompanyRegistrationManagement/CompanyRegistrationManagement.jsx
+++ b/frontend/src/pages/SuperAdmin/CompanyRegistrationManagement/CompanyRegistrationManagement.jsx
@@ -55,9 +55,6 @@ const CompanyRegistrationManagement = () => {
   const handleViewDetail = async (application) => {
     try {
       const response = await airlineApplyService.getApplicationDetail(application.id);
-      console.log('=== 상세 정보 응답 ===', response.data);
-      console.log('airlineId:', response.data.airlineId);
-      console.log('status:', response.data.status);
       setSelectedApplication(response.data);
       setModalType(application.status);
     } catch (err) {
@@ -316,17 +313,17 @@ const PendingModal = ({ application, onClose, onApprove, onReject }) => {
                     : '이메일 도메인이 일치하지 않습니다.'}
                 </S.StepDescription>
               </S.ProgressStep>
-              <S.ProgressStep completed>
+              <S.ProgressStep $completed={true}>
                 <S.StepIcon>✓</S.StepIcon>
                 <S.StepLabel>필수 서류 제출</S.StepLabel>
                 <S.StepDescription>모든 필수 서류가 제출되었습니다.</S.StepDescription>
               </S.ProgressStep>
-              <S.ProgressStep completed>
+              <S.ProgressStep $completed={true}>
                 <S.StepIcon>✓</S.StepIcon>
                 <S.StepLabel>이메일 확인 유효성</S.StepLabel>
                 <S.StepDescription>이메일 확인이 완료되었습니다.</S.StepDescription>
               </S.ProgressStep>
-              <S.ProgressStep completed>
+              <S.ProgressStep $completed={true}>
                 <S.StepIcon>✓</S.StepIcon>
                 <S.StepLabel>사업자 등록증 확인</S.StepLabel>
                 <S.StepDescription>사업자 등록증이 검토되었습니다.</S.StepDescription>
@@ -421,15 +418,11 @@ const PendingModal = ({ application, onClose, onApprove, onReject }) => {
 const ApprovedModal = ({ application, onClose }) => {
   const navigate = useNavigate();
 
-  console.log('=== ApprovedModal 렌더링 ===');
-  console.log('application:', application);
-  console.log('application.airlineId:', application.airlineId);
-
   const handleViewTenant = () => {
     if (application.airlineId) {
       navigate(`/super-admin/tenants/${application.airlineId}`);
     } else {
-      alert('테넌트 정보를 찾을 수 없습니다.');
+      alert('테넌트 정보를 불러오는 중입니다. 잠시 후 다시 시도해주세요.');
     }
   };
 
@@ -513,14 +506,10 @@ const ApprovedModal = ({ application, onClose }) => {
         </S.ModalContent>
 
         <S.ModalFooter>
-          {application.airlineId ? (
+          {application.airlineId && (
             <S.ApproveButton onClick={handleViewTenant} style={{ marginRight: '10px' }}>
               🏢 테넌트 상세보기
             </S.ApproveButton>
-          ) : (
-            <div style={{ fontSize: '12px', color: '#999', marginRight: 'auto' }}>
-              ℹ️ 이 신청은 구버전에서 승인되어 테넌트 정보가 없습니다.
-            </div>
           )}
           <S.CloseOnlyButton onClick={onClose}>닫기</S.CloseOnlyButton>
         </S.ModalFooter>


### PR DESCRIPTION
## 무엇을 변경했는가
- 관리자 계정 ID 자동생성을 위한 백엔드 로직 수정

## 관련 이슈
- 슈퍼관리자 대시보드에서 신청 승인을 한 뒤 아이디 입력하면 발생하던 오류 수정

## 테스트 방법

- 
## 체크리스트

- 