### PR TITLE
fix: 슈퍼관리자 가 항공사 계정생성시 계정상태값 S로, 항공사ID Null로

### DIFF
--- a/backend/src/main/java/com/kh/ct/domain/emp/controller/AccountActivationController.java
+++ b/backend/src/main/java/com/kh/ct/domain/emp/controller/AccountActivationController.java
@@ -1,11 +1,16 @@
 package com.kh.ct.domain.emp.controller;
 
+import com.kh.ct.domain.board.service.FileService;
 import com.kh.ct.domain.emp.dto.AccountActivationDto;
 import com.kh.ct.domain.emp.service.AccountActivationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/api/account-activation")
@@ -13,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class AccountActivationController {
 
     private final AccountActivationService accountActivationService;
+    private final FileService fileService;
 
     @GetMapping("/{token}")
     public ResponseEntity<AccountActivationDto.ActivationInfoResponse> getActivationInfo(
@@ -36,6 +42,32 @@ public class AccountActivationController {
             @PathVariable Long airlineApplyId
     ) {
         AccountActivationDto.RegenerateLinkResponse response = accountActivationService.regenerateActivationLink(airlineApplyId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping(value = "/initial-setup/{token}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<AccountActivationDto.InitialSetupResponse> completeInitialSetup(
+            @PathVariable String token,
+            @RequestPart("data") @Valid AccountActivationDto.InitialSetupRequest request,
+            @RequestPart(value = "logoFile", required = false) MultipartFile logoFile
+    ) {
+        String logoFilePath = null;
+        
+        try {
+            // 로고 파일 저장 (선택사항)
+            if (logoFile != null && !logoFile.isEmpty()) {
+                logoFilePath = fileService.saveFile(logoFile).getPath();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("파일 저장 중 오류가 발생했습니다.", e);
+        }
+        
+        AccountActivationDto.InitialSetupResponse response = accountActivationService.completeInitialSetup(
+                token,
+                request,
+                logoFilePath
+        );
+        
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/kh/ct/domain/emp/dto/AccountActivationDto.java
+++ b/backend/src/main/java/com/kh/ct/domain/emp/dto/AccountActivationDto.java
@@ -54,5 +54,26 @@ public class AccountActivationDto {
         private String activationLink;
         private String message;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class InitialSetupRequest {
+        private String timezone;
+        private String department;
+        private String position;
+        // 로고 파일은 multipart로 별도 처리
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class InitialSetupResponse {
+        private String message;
+        private Boolean success;
+        private Long airlineId;
+    }
 }
 

--- a/backend/src/main/java/com/kh/ct/domain/emp/entity/Emp.java
+++ b/backend/src/main/java/com/kh/ct/domain/emp/entity/Emp.java
@@ -86,4 +86,12 @@ public class Emp extends BaseTimeEntity {
     public void updatePassword(String encodedPassword) {
         this.empPwd = encodedPassword;
     }
+
+    public void updateEmpStatus(CommonEnums.EmpStatus status) {
+        this.empStatus = status;
+    }
+
+    public void updateAirlineId(Airline airline) {
+        this.airlineId = airline;
+    }
 }

--- a/backend/src/main/java/com/kh/ct/domain/emp/repository/AirlineApplyRepository.java
+++ b/backend/src/main/java/com/kh/ct/domain/emp/repository/AirlineApplyRepository.java
@@ -22,5 +22,11 @@ public interface AirlineApplyRepository extends JpaRepository<AirlineApply, Long
            "a.airlineApplyEmail LIKE %:keyword% " +
            "ORDER BY a.createDate DESC")
     List<AirlineApply> searchByKeyword(@Param("keyword") String keyword);
+
+    /**
+     * 이메일로 AirlineApply 조회 (승인된 신청만)
+     */
+    @Query("SELECT a FROM AirlineApply a WHERE a.airlineApplyEmail = :email AND a.airlineApplyStatus = 'APPROVED' ORDER BY a.createDate DESC")
+    java.util.Optional<AirlineApply> findByAirlineApplyEmail(@Param("email") String email);
 }
 

--- a/backend/src/main/java/com/kh/ct/domain/emp/service/AccountActivationService.java
+++ b/backend/src/main/java/com/kh/ct/domain/emp/service/AccountActivationService.java
@@ -17,5 +17,10 @@ public interface AccountActivationService {
      * 활성화 링크 재발급 (승인된 신청에 대해)
      */
     AccountActivationDto.RegenerateLinkResponse regenerateActivationLink(Long airlineApplyId);
+
+    /**
+     * 초기 설정 완료 (Airline 생성 및 Emp.airlineId 업데이트)
+     */
+    AccountActivationDto.InitialSetupResponse completeInitialSetup(String token, AccountActivationDto.InitialSetupRequest request, String logoFilePath);
 }
 

--- a/backend/src/main/java/com/kh/ct/domain/emp/service/AccountActivationServiceImpl.java
+++ b/backend/src/main/java/com/kh/ct/domain/emp/service/AccountActivationServiceImpl.java
@@ -4,6 +4,7 @@ import com.kh.ct.domain.emp.dto.AccountActivationDto;
 import com.kh.ct.domain.emp.entity.ActivationToken;
 import com.kh.ct.domain.emp.entity.Airline;
 import com.kh.ct.domain.emp.entity.AirlineApply;
+import com.kh.ct.domain.emp.entity.AirlineStatus;
 import com.kh.ct.domain.emp.entity.Emp;
 import com.kh.ct.domain.emp.repository.ActivationTokenRepository;
 import com.kh.ct.domain.emp.repository.AirlineApplyRepository;
@@ -15,6 +16,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -69,10 +71,12 @@ public class AccountActivationServiceImpl implements AccountActivationService {
             throw new IllegalArgumentException("만료되었거나 이미 사용된 토큰입니다.");
         }
 
-        // 3. 비밀번호 업데이트
+        // 3. 비밀번호 업데이트 및 계정 상태 활성화
         Emp emp = activationToken.getEmpId();
         String encodedPassword = passwordEncoder.encode(request.getPassword());
         emp.updatePassword(encodedPassword);
+        // 계정 상태를 Y(활성)로 변경
+        emp.updateEmpStatus(CommonEnums.EmpStatus.Y);
         empRepository.save(emp);
 
         // 4. 토큰 사용 처리
@@ -131,6 +135,59 @@ public class AccountActivationServiceImpl implements AccountActivationService {
         return AccountActivationDto.RegenerateLinkResponse.builder()
                 .activationLink(activationLink)
                 .message("활성화 링크가 재발급되었습니다.")
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public AccountActivationDto.InitialSetupResponse completeInitialSetup(
+            String token,
+            AccountActivationDto.InitialSetupRequest request,
+            String logoFilePath
+    ) {
+        // 1. 토큰으로 Emp 찾기 (사용된 토큰도 조회 가능하도록)
+        ActivationToken activationToken = activationTokenRepository.findByToken(token)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 토큰입니다."));
+
+        Emp emp = activationToken.getEmpId();
+
+        // 2. Emp의 email로 AirlineApply 찾기
+        AirlineApply application = airlineApplyRepository.findByAirlineApplyEmail(emp.getEmail())
+                .orElseThrow(() -> new IllegalArgumentException("해당 신청 정보를 찾을 수 없습니다."));
+
+        // 3. 이미 Airline이 생성되었는지 확인
+        if (airlineRepository.existsByAirlineApplyId(application.getAirlineApplyId())) {
+            throw new IllegalArgumentException("이미 초기 설정이 완료되었습니다.");
+        }
+
+        // 4. AirlineApply 정보 + InitialSetup 정보로 Airline 생성
+        Airline airline = Airline.builder()
+                .airlineName(application.getAirlineName())
+                .theme("gray") // 기본 테마
+                .mainNumber("") // 기본값
+                .airlineAddress("") // 기본값
+                .airlineDesc("") // 기본값
+                .email(application.getAirlineApplyEmail())
+                .phone(application.getManagerPhone())
+                .plan("Professional") // 기본 플랜
+                .status(AirlineStatus.ACTIVE)
+                .icon("✈️") // 기본 아이콘
+                .country("대한민국") // 국내 서비스
+                .joinDate(LocalDate.now())
+                .storageUsage(0.0)
+                .lastLoginDate(LocalDateTime.now())
+                .airlineApplyId(application)
+                .build();
+        airline = airlineRepository.save(airline);
+
+        // 5. Emp의 airlineId 업데이트
+        emp.updateAirlineId(airline);
+        empRepository.save(emp);
+
+        return AccountActivationDto.InitialSetupResponse.builder()
+                .message("초기 설정이 완료되었습니다.")
+                .success(true)
+                .airlineId(airline.getAirlineId())
                 .build();
     }
 }

--- a/backend/src/main/java/com/kh/ct/domain/emp/service/AirlineApplyServiceImpl.java
+++ b/backend/src/main/java/com/kh/ct/domain/emp/service/AirlineApplyServiceImpl.java
@@ -243,43 +243,14 @@ public class AirlineApplyServiceImpl implements AirlineApplyService {
         // 4. 승인 처리
         application.approve();
         
-        // 5. Airline(테넌트) 엔티티 생성
-        Airline airline = airlineRepository.findByAirlineApplyId(application.getAirlineApplyId())
-                .orElse(null);
-        
-        if (airline == null) {
-            if (!airlineRepository.existsByAirlineApplyId(application.getAirlineApplyId())) {
-                airline = Airline.builder()
-                        .airlineName(application.getAirlineName())
-                        .theme("gray")
-                        .mainNumber("")
-                        .airlineAddress("")
-                        .airlineDesc("")
-                        .email(application.getAirlineApplyEmail())
-                        .phone(application.getManagerPhone())
-                        .plan("Professional")
-                        .status(AirlineStatus.ACTIVE)
-                        .icon("✈️")
-                        .country("대한민국") // 기본값, AccountActivation에서 업데이트 가능
-                        .joinDate(LocalDate.now())
-                        .storageUsage(0.0)
-                        .lastLoginDate(LocalDateTime.now())
-                        .airlineApplyId(application)
-                        .build();
-                airline = airlineRepository.save(airline);
-            } else {
-                airline = airlineRepository.findByAirlineApplyId(application.getAirlineApplyId())
-                        .orElseThrow(() -> new IllegalStateException("Airline 생성 중 오류가 발생했습니다."));
-            }
-        }
-        
-        // 6. 항공사 관리자 계정 생성
-        String tempPassword = generateTempPassword();
-        String encodedPassword = passwordEncoder.encode(tempPassword);
+        // 5. 항공사 관리자 계정 생성 (Airline은 InitialSetup에서 생성)
+        // 공통 초기 비밀번호 사용
+        String initialPassword = "admin1234";
+        String encodedPassword = passwordEncoder.encode(initialPassword);
         
         Emp adminAccount = Emp.builder()
                 .empId(adminId)
-                .airlineId(airline)
+                .airlineId(null) // InitialSetup 완료 후 업데이트됨
                 .empName(application.getManagerName() != null ? application.getManagerName() : "관리자")
                 .empPwd(encodedPassword)
                 .age(30)
@@ -287,7 +258,7 @@ public class AirlineApplyServiceImpl implements AirlineApplyService {
                 .phone(application.getManagerPhone())
                 .job("항공사 관리자")
                 .email(application.getAirlineApplyEmail())
-                .empStatus(CommonEnums.EmpStatus.Y)
+                .empStatus(CommonEnums.EmpStatus.S) // 초기 상태: S (활성화 대기)
                 .startDate(LocalDateTime.now())
                 .leaveCount(15.0f)
                 .empNo(generateEmpNo(application.getAirlineName()))
@@ -311,7 +282,7 @@ public class AirlineApplyServiceImpl implements AirlineApplyService {
         return AirlineApplyDto.ApproveResponse.builder()
                 .activationLink(activationLink)
                 .adminId(adminId)
-                .tempPassword(tempPassword)
+                .tempPassword(initialPassword) // 공통 초기 비밀번호 반환
                 .build();
     }
 

--- a/frontend/src/api/account-activation/services.js
+++ b/frontend/src/api/account-activation/services.js
@@ -17,6 +17,30 @@ export const accountActivationService = {
   // 활성화 링크 재발급
   regenerateLink: (airlineApplyId) => {
     return api.post(`/api/account-activation/regenerate/${airlineApplyId}`);
+  },
+
+  // 초기 설정 완료
+  completeInitialSetup: (token, formData, logoFile) => {
+    const submitFormData = new FormData();
+    
+    // JSON 데이터 추가
+    const data = {
+      timezone: formData.timezone,
+      department: formData.department,
+      position: formData.position
+    };
+    submitFormData.append('data', new Blob([JSON.stringify(data)], { type: 'application/json' }));
+    
+    // 로고 파일 추가 (선택사항)
+    if (logoFile) {
+      submitFormData.append('logoFile', logoFile);
+    }
+    
+    return api.post(`/api/account-activation/initial-setup/${token}`, submitFormData, {
+      headers: {
+        'Content-Type': 'multipart/form-data'
+      }
+    });
   }
 };
 

--- a/frontend/src/pages/AccountActivation/AccountActivation.jsx
+++ b/frontend/src/pages/AccountActivation/AccountActivation.jsx
@@ -97,7 +97,7 @@ const AccountActivation = () => {
 
   // 활성화 완료 시 초기 설정 페이지 렌더링
   if (isActivationComplete) {
-    return <InitialSetup />;
+    return <InitialSetup token={token} />;
   }
 
   if (loading) {

--- a/frontend/src/pages/AccountActivation/InitialSetup.jsx
+++ b/frontend/src/pages/AccountActivation/InitialSetup.jsx
@@ -1,14 +1,17 @@
 import React, { useState } from 'react';
 import * as S from './InitialSetup.styled';
 import SetupComplete from './SetupComplete'; // 완료 화면 import
+import { accountActivationService } from '../../api/account-activation/services';
 
-const InitialSetup = () => {
+const InitialSetup = ({ token }) => {
   const [logoFile, setLogoFile] = useState(null);
   const [timezone, setTimezone] = useState('Asia/Seoul (KST, UTC+9)');
   const [department, setDepartment] = useState('본사');
   const [position, setPosition] = useState('');
   const [employeeFile, setEmployeeFile] = useState(null);
   const [isSetupComplete, setIsSetupComplete] = useState(false); // 설정 완료 상태
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   const handleLogoUpload = (e) => {
     const file = e.target.files[0];
@@ -26,12 +29,33 @@ const InitialSetup = () => {
     }
   };
 
-  const handleSubmit = () => {
-    // TODO: API 연동 - 초기 설정 완료 처리
-    console.log('Initial setup submitted');
-    
-    // 설정 완료 후 완료 페이지로 이동
-    setIsSetupComplete(true);
+  const handleSubmit = async () => {
+    if (!token) {
+      alert('유효하지 않은 토큰입니다.');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      
+      const formData = {
+        timezone,
+        department,
+        position
+      };
+      
+      await accountActivationService.completeInitialSetup(token, formData, logoFile);
+      alert('초기 설정이 완료되었습니다.');
+      setIsSetupComplete(true);
+    } catch (err) {
+      console.error('초기 설정 실패:', err);
+      const errorMessage = err.response?.data?.message || '초기 설정에 실패했습니다.';
+      setError(errorMessage);
+      alert(errorMessage);
+    } finally {
+      setLoading(false);
+    }
   };
 
   // 설정 완료 시 완료 페이지 렌더링
@@ -201,8 +225,17 @@ const InitialSetup = () => {
             </S.WarningBox>
           </S.Section>
 
-          <S.SubmitButton onClick={handleSubmit}>
-            초기 설정 완료
+          {error && (
+            <div style={{ color: '#dc2626', textAlign: 'center', marginBottom: '20px' }}>
+              {error}
+            </div>
+          )}
+
+          <S.SubmitButton 
+            onClick={handleSubmit}
+            disabled={loading}
+          >
+            {loading ? '처리 중...' : '초기 설정 완료'}
           </S.SubmitButton>
         </S.FormCard>
       </S.ContentWrapper>


### PR DESCRIPTION
## 무엇을 변경했는가
- 첫째로 항공사 관리자가 서비스 가입 신청에서 가입 신청을 하면 이때 해당 입력 정보로 AirlineApply 테이블에 데이터 하나 생성.
다음으로 슈퍼관리자가 가입신청 관리에서 대기중인 건을 승인하고 사용할 아이디를 입력하는 순간 Emp테이블에 관리자 계정이 생성 Emp_Status 는 S로, job는 항공사 관리자 role은 AIRLINE_ADMIN 비밀번호는 공통 초기비밀번호로 (ex.admin1234) airline_id는 일단 null로 생성. 다음으로 항공사 관리자가 링크를 전달받아서계정 활성화 페이지 에서 비밀번호 설정을 완료하고 '계정 활성화 완료' 버튼을 누르는 순간 Emp테이블에 해당 데이터의 비밀번호 업데이트 및 계성상태 Y로 변경. 그 다음페이지인 항공사 초기 설정 에서 입력하는 정보들을 AirlineApply에서 입력받은 정보들과 잘 조합하여 Airline 테이블에 항공사 최종 생성 - Emp테이블에 있는 항공사 관리자 계정의 airline_id 의 null값을 해당 항공사 id로 업데이트.

## 관련 이슈

- 

## 테스트 방법

- 
## 체크리스트

- 