### PR TITLE
fix - board,Qna dashboard

### DIFF
--- a/backend/src/main/java/com/kh/ct/Application/admin_dashboard/controller/Admin_Dashboard_Controller.java
+++ b/backend/src/main/java/com/kh/ct/Application/admin_dashboard/controller/Admin_Dashboard_Controller.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@CrossOrigin(origins = "http://localhost:5173")
 @RestController
 @RequestMapping("/api/dashboard/admin")
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/kh/ct/Application/admin_dashboard/repository/Admin_Dashboard_RepositoryImpl.java
+++ b/backend/src/main/java/com/kh/ct/Application/admin_dashboard/repository/Admin_Dashboard_RepositoryImpl.java
@@ -190,7 +190,7 @@ public class Admin_Dashboard_RepositoryImpl implements Admin_Dashboard_Repositor
         public List<GroundSchedule> findGroundSchedulesByEmpId(String empId) {
                 return em.createQuery(
                                 "select g from GroundSchedule g where g.empId.empId = :empId " +
-                                                "order by g.scheduleStartDate asc",
+                                                "order by g.scheduleStartDateTime asc",
                                 GroundSchedule.class)
                                 .setParameter("empId", empId)
                                 .setMaxResults(3)

--- a/backend/src/main/java/com/kh/ct/Application/member_dashboard/controller/Dashboard_Controller.java
+++ b/backend/src/main/java/com/kh/ct/Application/member_dashboard/controller/Dashboard_Controller.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@CrossOrigin(origins = "http://localhost:5173")
 @RestController
 @RequestMapping("/api/dashboard")
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/kh/ct/Application/member_dashboard/repository/Dashboard_RepositoryImpl.java
+++ b/backend/src/main/java/com/kh/ct/Application/member_dashboard/repository/Dashboard_RepositoryImpl.java
@@ -117,7 +117,7 @@ public class Dashboard_RepositoryImpl implements Dashboard_Repository {
     public List<GroundSchedule> findGroundSchedulesByEmpId(String empId) {
         return em.createQuery(
                         "select g from GroundSchedule g where g.empId.empId = :empId " +
-                                "order by g.scheduleStartDate asc", GroundSchedule.class)
+                                "order by g.scheduleStartDateTime asc", GroundSchedule.class)
                 .setParameter("empId", empId)
                 .setMaxResults(3)
                 .getResultList();

--- a/backend/src/main/java/com/kh/ct/domain/board/controller/BoardController.java
+++ b/backend/src/main/java/com/kh/ct/domain/board/controller/BoardController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 
-@CrossOrigin(origins = "http://localhost:5173")
 @RestController
 @RequestMapping("/api/board")
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/kh/ct/domain/chatbot/controller/ChatController.java
+++ b/backend/src/main/java/com/kh/ct/domain/chatbot/controller/ChatController.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api")
-@CrossOrigin(origins = "http://localhost:5173")
 @RequiredArgsConstructor
 public class ChatController {
 

--- a/backend/src/main/java/com/kh/ct/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/kh/ct/global/config/SecurityConfig.java
@@ -65,6 +65,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/health/save").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/airline-applications").permitAll()
                         .requestMatchers("/api/questions/**").permitAll()
+                        .requestMatchers("/api/dashboard/**").permitAll()
+                        .requestMatchers("/api/dashboard/admin/**").hasRole("AIRLINE_ADMIN")
+                        .requestMatchers("/api/board/**").permitAll()
                         .requestMatchers("/api/common/codes/**").permitAll()
                         .requestMatchers("/api/airlines").permitAll()
                         .requestMatchers("/api/airports").permitAll()
@@ -123,8 +126,10 @@ public class SecurityConfig {
         corsConfiguration.setAllowedOrigins(Arrays.asList(
                 "http://localhost:5173",
                 "http://localhost:5174",
-                "https://khair-controlltower.site",
-                "http://khair-controlltower.site"
+                "https://wkdwlsdn.shop",
+                "http://wkdwlsdn.shop"
+              //  "https://api.wkdwlsdn.shop",
+               // "http://api.wkdwlsdn.shop"
         ));
         corsConfiguration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         corsConfiguration.addAllowedHeader("*");

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -23,7 +23,7 @@ spring:
             enable: true
 
 server:
-  port: 8080
+  port: 8001
   servlet:
     encoding:
       charset: UTF-8
@@ -45,7 +45,7 @@ app:
   upload:
     path: ${FILE_UPLOAD_PATH:ct_uploads}
   frontend:
-    base-url: ${FRONTEND_BASE_URL:https://api.khair-controlltower.site}
+    base-url: ${FRONTEND_BASE_URL:https://wkdwlsdn.shop}
 
 # EC2/운영: 실행 전 export JWT_SECRET=실제비밀문자열 (선택: JWT_EXPIRATION=86400000)
 jwt:
@@ -66,6 +66,14 @@ spring:
     activate:
       on-profile: dev
 
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver # MySQL 드라이버
+    # 2. 시크릿 파일에 있는 변수 값을 여기에 주입합니다.
+    url: ${DATASOURCE.URL}
+    username: ${DATASOURCE.USERNAME}
+    password: ${DATASOURCE.PASSWORD}
+
+  # JPA 설정 (MySQL용)
   jpa:
     hibernate:
       ddl-auto: update

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,4 +1,4 @@
 #API 설정
-VITE_API_URL=http://localhost:8001
+VITE_API_URL=https://api.wkdwlsdn.shop
 VITE_API_TIMEOUT=5000
 VITE_API_VERSION=v1

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,4 +1,4 @@
 # 프로덕션 빌드 시 API 서버 (EC2 백엔드)
-VITE_API_URL=https://api.khair-controlltower.site
+VITE_API_URL=https://api.wkdwlsdn.shop
 VITE_API_TIMEOUT=5000
 VITE_API_VERSION=v1

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1421,8 +1421,7 @@
     "node_modules/@stomp/stompjs": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.3.0.tgz",
-      "integrity": "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1946,7 +1945,6 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
-      "license": "MIT",
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -4276,7 +4274,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.1.tgz",
       "integrity": "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==",
-      "license": "MIT",
       "peerDependencies": {
         "chart.js": "^4.1.1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -4736,7 +4733,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
       "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
-      "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7",
         "eventsource": "^2.0.2",

--- a/frontend/src/api/config.js
+++ b/frontend/src/api/config.js
@@ -1,7 +1,7 @@
 const { VITE_API_URL, VITE_API_TIMEOUT = 5000, VITE_API_VERSION = 'v1' } = import.meta.env;
 
 // 프로덕션 기본 API URL (빌드 시 VITE_API_URL 미설정 시 사용)
-const PRODUCTION_API_BASE = 'https://api.khair-controlltower.site';
+const PRODUCTION_API_BASE = 'https://api.wkdwlsdn.shop';
 
 export const API_CONFIG = {
   // 개발: 빈 문자열(프록시) / 프로덕션: VITE_API_URL 또는 기본값

--- a/frontend/src/pages/EmployeeDashboard/dashboardApi.js
+++ b/frontend/src/pages/EmployeeDashboard/dashboardApi.js
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios from "../../api/axios";
 import { getApiBaseUrl } from "../../api/config";
 
 const BASE_URL = `${getApiBaseUrl()}/api/dashboard`;

--- a/frontend/src/pages/QnA/QnA.jsx
+++ b/frontend/src/pages/QnA/QnA.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import axios from 'axios';
+import axios from '../../api/axios';
 import * as S from './QnA.styled';
 import { useTheme } from 'styled-components'; // Import useTheme
 import {

--- a/frontend/src/pages/QnADetail/QnADetail.jsx
+++ b/frontend/src/pages/QnADetail/QnADetail.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import axios from 'axios';
+import axios from '../../api/axios';
 import * as S from "../QnA/QnA.styled"; // 기존 스타일 재활용
 import * as D from './QnADetail.styled'; // 상세 페이지 전용 스타일
 import {

--- a/frontend/src/pages/board/board.jsx
+++ b/frontend/src/pages/board/board.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './Board.styled';
 import { Search, MessageSquare, Eye, Send, X } from 'lucide-react';
+import api, { uploadApi } from '../../api/axios.js';
 
 const Board = () => {
   const navigate = useNavigate();
@@ -34,14 +35,14 @@ const Board = () => {
       if (category !== '전체') params.append('category', category);
       if (keyword) params.append('keyword', keyword);
 
-      const response = await fetch(`http://localhost:8001/api/board/list?${params.toString()}`, {
+      const response = await api.get(`/api/board/list?${params.toString()}`, {
         headers: {
           'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json'
         }
       });
 
-      const data = await response.json();
+      const data = response.data;
       setBoardList(data.content || []);
       setTotalPages(data.totalPages || 0);
       setCurrentPage(data.number || 0);
@@ -101,17 +102,13 @@ const Board = () => {
     });
 
     try {
-      const response = await fetch('http://localhost:8001/api/board/write', {
-        method: 'POST',
-        headers: { 'Authorization': `Bearer ${token}` },
-        body: formDataObj, // 브라우저가 자동으로 multipart/form-data 설정
-      });
+      const response = await uploadApi.post('/api/board/write', formDataObj);
 
-      if (response.ok) {
-        alert("등록되었습니다.");
-        handleCloseModal();
-        fetchPosts(activeTab, 0);
-      }
+    if (response.status === 200 || response.status === 201) {
+      alert("등록되었습니다.");
+      handleCloseModal();
+      fetchPosts(activeTab, 0);
+    }
     } catch (error) {
       console.error("글쓰기 실패:", error);
     }

--- a/frontend/src/pages/boardDetail/boardDetail.jsx
+++ b/frontend/src/pages/boardDetail/boardDetail.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import * as S from './BoardDetail.styled';
 import { ArrowLeft, Calendar, Eye, User, Edit3, Trash2 } from 'lucide-react';
 import { Paperclip, Download } from 'lucide-react';
+import api from '../../api/axios.js';
 
 const BoardDetail = () => {
   const navigate = useNavigate();
@@ -22,31 +23,16 @@ const handleDownload = (fileId, fileName) => {
     const fetchPostDetail = async () => {
       try {
         setLoading(true);
-        const storageData = JSON.parse(localStorage.getItem('auth-storage'));
-        const token = storageData?.state?.token;
-
-        // 상세 조회 API 호출 (URL은 백엔드 엔드포인트에 맞게 조정하세요)
-        const response = await fetch(`http://localhost:8001/api/board/detail/${boardId}`, {
-         
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'Content-Type': 'application/json'
-          }
-        });
-
-        if (response.ok) {
-          const data = await response.json();
-          console.log("게시글 상세 정보:", data);
-          setPost(data);
-          
-        } else {
-          isFetched.current = false;
-          alert("게시글을 불러올 수 없습니다.");
-          navigate('/board');
-        }
+        // ✅ api.get 사용 (토큰은 인터셉터가 자동으로 넣어줌)
+        const response = await api.get(`/api/board/detail/${boardId}`);
+        
+        // ✅ axios는 response.data에 결과가 담김
+        setPost(response.data);
+        isFetched.current = true;
       } catch (error) {
-        isFetched.current = false;
         console.error("상세 데이터 로드 실패:", error);
+        alert("게시글을 불러올 수 없습니다.");
+        navigate('/board');
       } finally {
         setLoading(false);
       }
@@ -61,25 +47,17 @@ const handleDownload = (fileId, fileName) => {
   const handleDelete = async () => {
     if (!window.confirm("정말로 이 게시글을 삭제하시겠습니까?")) return;
 
-    try {
-      const storageData = JSON.parse(localStorage.getItem('auth-storage'));
-      const token = storageData?.state?.token;
+try {
+      // ✅ api.delete 사용
+      const response = await api.delete(`/api/board/delete/${boardId}`);
 
-      const response = await fetch(`http://localhost:8001/api/board/delete/${boardId}`, {
-        method: 'DELETE', // 보통 삭제는 DELETE 메소드를 사용합니다.
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
-      });
-
-      if (response.ok) {
+      if (response.status === 200 || response.status === 204) {
         alert("삭제되었습니다.");
         navigate('/board');
-      } else {
-        alert("삭제에 실패했습니다.");
       }
     } catch (error) {
       console.error("삭제 실패:", error);
+      alert("삭제 권한이 없거나 오류가 발생했습니다.");
     }
   };
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -21,7 +21,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:8001',
+        target: 'https://api.wkdwlsdn.shop',
         changeOrigin: true,
         secure: false,
         rewrite: (path) => path, // 경로를 그대로 유지


### PR DESCRIPTION
## 무엇을 변경했는가
1. 각 대시보드 (직원/관리자) crossorigin 삭제 후 시큐리티에 접근 제어 로직 추가
2. 게시판쪽 crossorigin 삭제 후 시큐리티에 접근 제어 로직 추가
3. 챗봇 crossorigin 삭제 (시큐리티에 이미 접근제어 있었음)
4. 서버 포트 8001로 수정 밑 url 내꺼 도메인 넣음 DB정보 삭제됐길래 넣었음
5. 시큐리티 corsConfigurationSource 에 도메인 추가

프론트 
1. env / env.production 파일 도메인 내껄로 수정 
2. config 도메인 내꺼만 넣음 (기본값 도메인) -> 누가 만져놔서 저도 같이 만짐 
3. vite에 내 도메인 넣음
4. 게시판 ( board , boardDetil) , 대시보드(직원용 Emp dashboard) , Qna (QnA) 원래 하드코딩되어잇던 url들 전부 axios , config에서 자동으로 받아오게 수정
5. boardDetail 파일 받아오기부분은 하드코딩으로 그대로 뒀음 
   자기꺼 할떄 수정하면됨 (2곳) 

## 관련 이슈

- 챗봇은 인사이드 규칙은 기본이고 아웃사이드 규칙하나 추가해야 됩니다.


## 테스트 방법

- 
## 체크리스트

- 